### PR TITLE
Pro Bowl Fix: Update __init__.py for team & opponent records & colors

### DIFF
--- a/custom_components/nfl/__init__.py
+++ b/custom_components/nfl/__init__.py
@@ -219,20 +219,38 @@ async def async_get_state(config) -> dict:
                 values["team_abbr"] = event["competitions"][0]["competitors"][team_index]["team"]["abbreviation"]
                 values["team_id"] = event["competitions"][0]["competitors"][team_index]["team"]["id"]
                 values["team_name"] = event["competitions"][0]["competitors"][team_index]["team"]["shortDisplayName"]
-                values["team_record"] = event["competitions"][0]["competitors"][team_index]["records"][0]["summary"]
+                try:
+                    values["team_record"] = event["competitions"][0]["competitors"][team_index]["records"][0]["summary"]
+                except:
+                    values["team_record"] = None
                 values["team_homeaway"] = event["competitions"][0]["competitors"][team_index]["homeAway"]
                 values["team_logo"] = event["competitions"][0]["competitors"][team_index]["team"]["logo"]
-                values["team_colors"] = [''.join(('#',event["competitions"][0]["competitors"][team_index]["team"]["color"])), 
+                try:
+                    values["team_colors"] = [''.join(('#',event["competitions"][0]["competitors"][team_index]["team"]["color"])), 
                                          ''.join(('#',event["competitions"][0]["competitors"][team_index]["team"]["alternateColor"]))]
+                except:
+                    if team_id == 'NFC':
+                        values["team_colors"] = ['#013369','#013369']
+                    if team_id == 'AFC':
+                        values["team_colors"] = ['#D50A0A','#D50A0A']
                 values["team_score"] = event["competitions"][0]["competitors"][team_index]["score"]                
                 values["opponent_abbr"] = event["competitions"][0]["competitors"][oppo_index]["team"]["abbreviation"]
                 values["opponent_id"] = event["competitions"][0]["competitors"][oppo_index]["team"]["id"]
                 values["opponent_name"] = event["competitions"][0]["competitors"][oppo_index]["team"]["shortDisplayName"]
-                values["opponent_record"] = event["competitions"][0]["competitors"][oppo_index]["records"][0]["summary"]
+                try:
+                    values["opponent_record"] = event["competitions"][0]["competitors"][oppo_index]["records"][0]["summary"]
+                except:
+                    values["opponent_record"] = None
                 values["opponent_homeaway"] = event["competitions"][0]["competitors"][oppo_index]["homeAway"]
                 values["opponent_logo"] = event["competitions"][0]["competitors"][oppo_index]["team"]["logo"]
-                values["opponent_colors"] = [''.join(('#',event["competitions"][0]["competitors"][oppo_index]["team"]["color"])),
-                                             ''.join(('#',event["competitions"][0]["competitors"][oppo_index]["team"]["alternateColor"]))]
+                try:
+                    values["opponent_colors"] = [''.join(('#',event["competitions"][0]["competitors"][team_index]["team"]["color"])), 
+                                         ''.join(('#',event["competitions"][0]["competitors"][team_index]["team"]["alternateColor"]))]
+                except:
+                    if team_id == 'AFC':
+                        values["opponent_colors"] = ['#013369','#013369']
+                    if team_id == 'NFC':
+                        values["opponent_colors"] = ['#D50A0A','#D50A0A']
                 values["opponent_score"] = event["competitions"][0]["competitors"][oppo_index]["score"]
                 values["last_update"] = arrow.now().format(arrow.FORMAT_W3C)
                 values["private_fast_refresh"] = False


### PR DESCRIPTION
Proposed fix for Pro Bowl data missing team & opponent records and colors (records become None, colors are hard coded to a blue for NFC and a red for AFC).