### PR TITLE
Update __init__.py to guard against empty broadcasts fields

### DIFF
--- a/custom_components/nfl/__init__.py
+++ b/custom_components/nfl/__init__.py
@@ -169,7 +169,10 @@ async def async_get_state(config) -> dict:
                 values["kickoff_in"] = arrow.get(event["date"]).humanize()
                 values["venue"] = event["competitions"][0]["venue"]["fullName"]
                 values["location"] = "%s, %s" % (event["competitions"][0]["venue"]["address"]["city"], event["competitions"][0]["venue"]["address"]["state"])
-                values["tv_network"] = event["competitions"][0]["broadcasts"][0]["names"][0]
+                try:
+                    values["tv_network"] = event["competitions"][0]["broadcasts"][0]["names"][0]
+                except:
+                    values["tv_network"] = None
                 if event["status"]["type"]["state"].lower() in ['pre']: # odds only exist pre-game
                     values["odds"] = event["competitions"][0]["odds"][0]["details"]
                     values["overunder"] = event["competitions"][0]["odds"][0]["overUnder"]


### PR DESCRIPTION
Found a number of my followed teams were coming up unavailable today, but not all of them (BUF was the only working one out of BUF, BAL, PHI, & JAX).  Stepping through the json, the broadcasts (event["competitions"][0]["broadcasts"][0]["names"][0]) were empty in each of the non-functioning teams.

A simple try/except block to assign None to the tv_network value if the broadcasts is found to be empty seems to work and the sensors then get populated.  @D34DC3N73R 's ha-nfl-card still looks ok without the tv network displayed.