### PR TITLE
London game fix (Location missing State info) and hacs default repo prep work

### DIFF
--- a/.github/workflows/hacs.yaml
+++ b/.github/workflows/hacs.yaml
@@ -1,0 +1,18 @@
+name: HACS Action
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  hacs:
+    name: HACS Action
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: HACS Action
+        uses: "hacs/action@main"
+        with:
+          category: "integration"
+          ignore: "images"

--- a/custom_components/nfl/__init__.py
+++ b/custom_components/nfl/__init__.py
@@ -201,10 +201,14 @@ async def async_get_state(config) -> dict:
                 values["date"] = event["date"]
                 values["kickoff_in"] = arrow.get(event["date"]).humanize()
                 values["venue"] = event["competitions"][0]["venue"]["fullName"]
-                values["location"] = "%s, %s" % (
-                    event["competitions"][0]["venue"]["address"]["city"],
-                    event["competitions"][0]["venue"]["address"]["state"],
-                )
+                try:
+                    values["location"] = "%s, %s" % (
+                        event["competitions"][0]["venue"]["address"]["city"],
+                        event["competitions"][0]["venue"]["address"]["state"] if (
+                        "state" in event["competitions"][0]["venue"]["address"] ) else ""
+                    )
+                except:
+                    values["location"] = event["competitions"][0]["venue"]["address"]["city"]
                 try:
                     values["tv_network"] = event["competitions"][0]["broadcasts"][0][
                         "names"

--- a/custom_components/nfl/translations/en.json
+++ b/custom_components/nfl/translations/en.json
@@ -7,8 +7,7 @@
           "team_id": "Team Acronym",
           "timeout": "Update Timeout (in seconds)"
         },
-        "description": "You can find your 2 or 3-letter acronym on the ESPN NFL page's banner, at the top score strip.",
-        "title": "NFL"
+        "description": "You can find your 2 or 3-letter acronym on the ESPN NFL page's banner, at the top score strip."
       }
     }
   },
@@ -20,8 +19,7 @@
           "team_id": "Team Acronym",
           "timeout": "Update Timeout (in seconds)"
         },
-        "description": "You can find your 2 or 3-letter acronym on the ESPN NFL page's banner, at the top score strip.",
-        "title": "NFL"
+        "description": "You can find your 2 or 3-letter acronym on the ESPN NFL page's banner, at the top score strip."
       }
     }
   }

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,5 @@
 {
     "name": "NFL",
-    "domains": [ "sensor" ],
     "homeassistant": "0.95.4",
     "iot_class": "Cloud Polling",
     "render_readme": true

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,5 @@
 {
     "name": "NFL",
     "homeassistant": "0.95.4",
-    "iot_class": "Cloud Polling",
     "render_readme": true
 }


### PR DESCRIPTION
wrap values["location"] in try/except to catch games with no State info (e.g. the 10/2/2022 MIN @ NO London game)