### PR TITLE
Blueprints directory, readme, and mobile app notifications blueprint

### DIFF
--- a/blueprints/nfl-game-score-notifications.yaml
+++ b/blueprints/nfl-game-score-notifications.yaml
@@ -1,11 +1,11 @@
 blueprint:
   domain: automation
-  name: NFL Game Score Notification
-  description: >
+  name: NFL Game Score
+  description: >-
     Designed for Home Assistant mobile app notifications.
     Will send a notification with NFL game information, triggered by any score change(optionally ignoring opponent scores).
     
-    
+     
     Requires the [ha-nfl integration by @zacs](https://github.com/zacs/ha-nfl).
     
     
@@ -38,6 +38,13 @@ blueprint:
             - "No"
           mode: list
       default: "Yes"
+    notification_link:
+      name: Notification Link
+      description: >
+        Optional. Enter a web address(e.g. https://www.espn.com/) or a home assistant dashboard relative url(e.g. /lovelace/football) to go to when clicking on a game's notification.
+      selector:
+        text:
+          type: url
 variables:
   notify_on_opponent_score: !input notify_on_opponent_score
   notify_targets: !input notify_targets
@@ -56,9 +63,9 @@ trigger:
     id: POST
 condition:
   - condition: template
-    value_template: '{{ (states(trigger.entity_id) in [ "IN" ]) or (trigger.to_state.state == "POST") }}'
+    value_template: '{{ (states(trigger.entity_id) in [ "IN" ] or trigger.to_state.state == "POST" ) }}'
   - condition: template
-    value_template: '{{ (trigger.id != "oppo_score") or (notify_on_opponent_score=="Yes") }}'
+    value_template: '{{ ( trigger.id != "oppo_score") or (notify_on_opponent_score=="Yes" ) }}'
 action:
   - repeat:
       for_each: "{{ notify_targets }}"
@@ -95,3 +102,5 @@ action:
             data:
               tag: '{{ state_attr(trigger.entity_id,"team_abbr")|lower }}-score'
               group: football
+              url: !input notification_link
+              clickAction: !input notification_link

--- a/blueprints/readme.md
+++ b/blueprints/readme.md
@@ -1,7 +1,7 @@
 # Some NFL Blueprints for Home Assistant
 
 ## NFL Game Score Notifications
-[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Fgonzotek%2Fha-nfl%2Fblob%2FBlueprint%2Fblueprints%2Fnfl-game-score-notifications.yaml)
+[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Fgonzotek%2Fha-nfl%2Fblob%2F%2Fblueprints%2Fnfl-game-score-notifications.yaml)
 
 This blueprint will produce mobile app notifications on any score change (td, field goal, extra point), optionally excluding opponent scores. The notification will include data such as the quarter and game clock at the point the score was reported by the api, timeouts remaining, and win probability. It will also report the final score when the game ends. The notifications will be grouped together (separate from other HA notifications) and include metadata tags that allow the individual notifications to be replaced as new scores come in (in practice this works a little bit like a poor man's version of Apple’s recently announced Live Activities, where you'll just see the latest information if you don’t swipe the notification away during a game).
 

--- a/blueprints/readme.md
+++ b/blueprints/readme.md
@@ -1,7 +1,7 @@
 # Some NFL Blueprints for Home Assistant
 
 ## NFL Game Score Notifications
-[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Fgonzotek%2Fha-nfl%2Fblob%2F%2Fblueprints%2Fnfl-game-score-notifications.yaml)
+[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Fgonzotek%2Fha-nfl%2Fblob%2Fmaster%2Fblueprints%2Fnfl-game-score-notifications.yaml)
 
 This blueprint will produce mobile app notifications on any score change (td, field goal, extra point), optionally excluding opponent scores. The notification will include data such as the quarter and game clock at the point the score was reported by the api, timeouts remaining, and win probability. It will also report the final score when the game ends. The notifications will be grouped together (separate from other HA notifications) and include metadata tags that allow the individual notifications to be replaced as new scores come in (in practice this works a little bit like a poor man's version of Apple’s recently announced Live Activities, where you'll just see the latest information if you don’t swipe the notification away during a game).
 

--- a/blueprints/readme.md
+++ b/blueprints/readme.md
@@ -1,7 +1,7 @@
 # Some NFL Blueprints for Home Assistant
 
 ## NFL Game Score Notifications
-[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Fgonzotek%2Fha-nfl%2Fblob%2Fmaster%2Fblueprints%2Fnfl-game-score-notifications.yaml)
+[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Fzacs%2Fha-nfl%2Fblob%2Fmaster%2Fblueprints%2Fnfl-game-score-notifications.yaml)
 
 This blueprint will produce mobile app notifications on any score change (td, field goal, extra point), optionally excluding opponent scores. The notification will include data such as the quarter and game clock at the point the score was reported by the api, timeouts remaining, and win probability. It will also report the final score when the game ends. The notifications will be grouped together (separate from other HA notifications) and include metadata tags that allow the individual notifications to be replaced as new scores come in (in practice this works a little bit like a poor man's version of Apple’s recently announced Live Activities, where you'll just see the latest information if you don’t swipe the notification away during a game).
 


### PR DESCRIPTION
This PR creates a blueprints directory, adds a readme.md file to it, and adds the first blueprint to it, mobile app notifications.  The readme file currently contains a description of the new blueprint and a "My Home Assistant" link for users to use to add it to their personal installations.  Note: that url won't actually work until after the PR is merged, as the blueprint file won't exist in the @zacs's repo until then.

I've tested the blueprint for several weeks running and have a high confidence that it won't cause massive issues(occasionally ESPN sends incorrect data which can cause an unnecessary notification, but this isn't very common).  It allows users to specify one or more existing nfl entities and one or more mobile app devices to notify.  The notifications get tagged and grouped, and can be linked to any website (e.g. ESPN.com) or Home Assistant dashboard view (e.g. /lovelace/football).