### PR TITLE
Add light color flasher blueprint and update blueprints readme.md

### DIFF
--- a/blueprints/nfl-game-score-lights.yaml
+++ b/blueprints/nfl-game-score-lights.yaml
@@ -1,0 +1,92 @@
+blueprint:
+  domain: automation
+  name: Light Up In NFL Team Colors on Score Changes
+  description: >
+    This blueprint will flash one or more lights using the team colors provided by the api, triggered by any score change (optionally ignoring opponent scores).
+    
+    
+    Requires the [ha-nfl integration by @zacs](https://github.com/zacs/ha-nfl).
+  input:
+    teams:
+      name: NFL Teams
+      description: NFL teams whose games you want to watch for score changes.
+      selector:
+        entity:
+          integration: nfl
+          multiple: true
+    light_targets:
+      name: Lights to flash
+      description: >-
+        Choose one or more lights.
+      selector:
+        entity:
+          domain: light
+          multiple: true
+    activate_on_opponent_score:
+      name: Activate on opponent score
+      description: >-
+        Enable to flash lights on any score change, disable to only activate when your team's score changes.  Colors will be those of whichever team has scored.
+      selector:
+        select:
+          options:
+            - "Yes"
+            - "No"
+          mode: list
+      default: "Yes"
+    repeat_count:
+      name: Repeat count
+      description: >-
+        How many times should the color cycle run?
+      selector:
+        number:
+          min: 1
+          max: 15
+          mode: slider
+      default: 3
+variables:
+  activate_on_opponent_score: !input activate_on_opponent_score
+trigger:
+  - platform: state
+    entity_id: !input teams
+    attribute: team_score
+    id: team_score
+  - platform: state
+    entity_id: !input teams
+    attribute: opponent_score
+    id: oppo_score
+condition:
+  - condition: template
+    value_template: '{{ (states(trigger.entity_id) in [ "IN" ]) }}'
+  - condition: template
+    value_template: '{{ (trigger.id != "oppo_score") or (activate_on_opponent_score == "Yes") }}'
+action:
+  - service: scene.create
+    data:
+      snapshot_entities:  !input light_targets
+      scene_id: nfl_game_score_lights_capture
+  - repeat:
+      count: !input repeat_count
+      sequence:
+        - service: light.turn_on
+          data:
+            rgb_color: "{{ state_attr(trigger.entity_id, 'team_colors_rbg')[0] if (trigger.id != 'oppo_score') else  state_attr(trigger.entity_id, 'opponent_colors_rgb')[0] }}"
+          target:
+            entity_id: !input light_targets
+        - delay:
+            hours: 0
+            minutes: 0
+            seconds: 1.5
+            milliseconds: 0
+        - service: light.turn_on
+          data:
+            rgb_color: "{{ state_attr(trigger.entity_id, 'team_colors_rbg')[1] if (trigger.id != 'oppo_score') else  state_attr(trigger.entity_id, 'opponent_colors_rgb')[1] }}"
+          target:
+            entity_id: !input light_targets
+        - delay:
+            hours: 0
+            minutes: 0
+            seconds: 1.5
+            milliseconds: 0
+  - service: scene.turn_on
+    target:
+      entity_id: scene.nfl_game_score_lights_capture

--- a/blueprints/readme.md
+++ b/blueprints/readme.md
@@ -6,3 +6,12 @@
 This blueprint will produce mobile app notifications on any score change (td, field goal, extra point), optionally excluding opponent scores. The notification will include data such as the quarter and game clock at the point the score was reported by the api, timeouts remaining, and win probability. It will also report the final score when the game ends. The notifications will be grouped together (separate from other HA notifications) and include metadata tags that allow the individual notifications to be replaced as new scores come in (in practice this works a little bit like a poor man's version of Apple’s recently announced Live Activities, where you'll just see the latest information if you don’t swipe the notification away during a game).
 
 You can track as many games and notify as many devices as you’d like, just select them in the automation.
+
+---
+
+## NFL Game Score Light Color Flasher
+[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Fzacs%2Fha-nfl%2Fblob%2Fmaster%2Fblueprints%2Fnfl-game-score-lights.yaml)
+
+This blueprint will flash one or more lights using the team (or opponent) colors provided by the api on any score change (td, field goal, extra point), optionally excluding opponent scores.
+
+You can track as many games and control as many lights as you’d like, just select them in the automation.  You can also select the number of times to cycle through the team colors (1-15 times).


### PR DESCRIPTION
Blueprint for Home Assistant color light flashing when teams score. Uses similar but simpler logic to the notifications blueprint.  User can select one or more nfl entities to monitor, and one or more lights to flash.  Also allows to control how many cycles to flash the light between the team two colors provided by the api (1-15, default 3).  Doesn't require a new release.