### PR TITLE
Hassfest action update

### DIFF
--- a/custom_components/nfl/manifest.json
+++ b/custom_components/nfl/manifest.json
@@ -1,12 +1,12 @@
 {
     "domain": "nfl",
     "name": "NFL",
-    "version": "0.1",
-    "documentation": "https://github.com/zacs/ha_nfl",
-    "issue_tracker": "https://github.com/zacs/ha_nfl/issues",
-    "dependencies": [],
     "codeowners": ["@zacs"],
     "config_flow": true,
+    "dependencies": [],
+    "documentation": "https://github.com/zacs/ha_nfl",
+    "iot_class": "cloud_polling",
+    "issue_tracker": "https://github.com/zacs/ha_nfl/issues",
     "requirements": ["arrow"],
-    "iot_class": "cloud_polling"
+    "version": "0.1"
   }

--- a/custom_components/nfl/manifest.json
+++ b/custom_components/nfl/manifest.json
@@ -8,5 +8,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/zacs/ha_nfl/issues",
     "requirements": ["arrow"],
-    "version": "0.1"
+    "version": "0.1.1"
   }


### PR DESCRIPTION
The Hassfest action (part of the Hacs "default repositories" inclusion requirements) started failing recently with an error message that the keys weren't sorted correctly.  This fixes that fail, and bumps the version from 0.1 to 0.1.1.

@zacs, do you have any interest in adding ha_nfl to hacs' default repositories?  It would make it more discoverable by users.  I'm willing to take responsibility for keeping up with required changes like this one.  Would also understand if you don't want to.