### PR TITLE
Bump manifest version to 0.7

### DIFF
--- a/custom_components/nfl/manifest.json
+++ b/custom_components/nfl/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "arrow"
   ],
-  "version": "0.1.1"
+  "version": "0.7"
 }


### PR DESCRIPTION
Bumps `custom_components/nfl/manifest.json` from `0.1.1` to `0.7` so the integration's reported version matches the `v0.7` release tag.

The manifest version had been left at `0.1.1` across prior releases (including `v0.6`), so this also brings it in line with the release tag going forward.

Companion to the `v0.7` release covering #55 (fixes #52).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRC5To1VHVRMUcD4u2faqM)_