### PR TITLE
Fix failing CI: Pytest on Python 3.13 + add MIT license

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.13"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 
 *.pyc
 .coverage
+coverage.xml

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Zac Schellhardt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto


### PR DESCRIPTION
Fixes the two red CI checks on `master` after v0.7.

## 1. Pytest failure (regression)

The `Pytest` workflow failed with 4 errors:

- `DataUpdateCoordinator.__init__() got an unexpected keyword argument 'config_entry'`
- `ConfigEntries.async_update_entry() got an unexpected keyword argument 'version'`

Both are APIs the deprecation fix (#55) now relies on, and both exist only in **modern** Home Assistant. The workflow pinned **Python 3.10**, where pip resolves to an old HA release that predates both APIs — so code that is correct for HA 2026.x failed against the ancient HA the CI installed.

**Fix:**
- Bump the `Pytest` matrix from `3.10` to `3.13` (Home Assistant 2026.x requires Python 3.13).
- Refresh `actions/checkout@v2 → v4` and `actions/setup-python@v1 → v5` (old majors run on deprecated Node 20 and don't reliably provide 3.13).

**Verification** — suite run locally on Python 3.13 with `homeassistant==2026.2.3`:

```
5 passed in 0.26s
```

## 2. HACS failure (pre-existing)

The `HACS Action` check failed with `<Validation license> failed: The repository has no license`. This was failing independently of the deprecation work — the repo had no `LICENSE` file.

**Fix:** add an MIT `LICENSE` file, which satisfies HACS's license validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)