### PR TITLE
Fix YAML config on modern HA (#49) and make refresh cadence adaptive (#46)

### DIFF
--- a/custom_components/nfl/__init__.py
+++ b/custom_components/nfl/__init__.py
@@ -32,6 +32,48 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# Polling cadence bounds.
+DEFAULT_SCAN_INTERVAL = timedelta(minutes=10)
+LIVE_SCAN_INTERVAL = timedelta(seconds=5)
+MIN_PREGAME_SCAN_INTERVAL = timedelta(seconds=5)
+# When kickoff is this close (or already elapsed while still reported as PRE),
+# poll at the fast pre-game cadence so we catch the PRE -> IN transition.
+IMMINENT_KICKOFF_WINDOW = timedelta(seconds=60)
+
+
+def _compute_update_interval(state, seconds_to_kickoff):
+    """Return how long to wait before the next data refresh.
+
+    Instead of a single fixed pre-game window that flips polling to a fast
+    cadence, the pre-game interval scales with the time remaining until
+    kickoff: the closer kickoff gets, the shorter the interval. This lets the
+    final pre-game poll land within seconds of kickoff without polling
+    aggressively for the entire pre-game period.
+    """
+    state = (state or "").upper()
+
+    if state == "IN":
+        # Game is live; poll frequently to track scores and plays.
+        return LIVE_SCAN_INTERVAL
+
+    if state == "PRE":
+        # ESPN can still report PRE slightly past the scheduled kickoff, so
+        # treat an unknown or already-elapsed kickoff as imminent.
+        if (
+            seconds_to_kickoff is None
+            or seconds_to_kickoff <= IMMINENT_KICKOFF_WINDOW.total_seconds()
+        ):
+            return MIN_PREGAME_SCAN_INTERVAL
+        # Halve the remaining time so the cadence converges on kickoff,
+        # clamped between the fast pre-game cadence and the default cadence.
+        seconds = seconds_to_kickoff / 2
+        seconds = max(MIN_PREGAME_SCAN_INTERVAL.total_seconds(), seconds)
+        seconds = min(DEFAULT_SCAN_INTERVAL.total_seconds(), seconds)
+        return timedelta(seconds=seconds)
+
+    # POST, BYE, NOT_FOUND, or anything unexpected: use the default cadence.
+    return DEFAULT_SCAN_INTERVAL
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Load the saved entities."""
@@ -141,7 +183,7 @@ class NFLDataUpdateCoordinator(DataUpdateCoordinator):
         config_entry: ConfigEntry | None = None,
     ):
         """Initialize."""
-        self.interval = timedelta(minutes=10)
+        self.interval = DEFAULT_SCAN_INTERVAL
         self.name = config[CONF_NAME]
         self.timeout = the_timeout
         self.config = config
@@ -162,13 +204,28 @@ class NFLDataUpdateCoordinator(DataUpdateCoordinator):
         async with timeout(self.timeout):
             try:
                 data = await update_game(self.config)
-                # update the interval based on flag
-                if data["private_fast_refresh"] == True:
-                    self.update_interval = timedelta(seconds=5)
-                else:
-                    self.update_interval = timedelta(minutes=10)
             except Exception as error:
                 raise UpdateFailed(error) from error
+
+            # Scale the next poll to the game state and time until kickoff.
+            seconds_to_kickoff = None
+            game_date = data.get("date")
+            if game_date is not None:
+                try:
+                    seconds_to_kickoff = (
+                        arrow.get(game_date) - arrow.now()
+                    ).total_seconds()
+                except (TypeError, ValueError):
+                    seconds_to_kickoff = None
+
+            self.update_interval = _compute_update_interval(
+                data.get("state"), seconds_to_kickoff
+            )
+            _LOGGER.debug(
+                "State is %s; next update in %s",
+                data.get("state"),
+                self.update_interval,
+            )
             return data
 
 
@@ -413,7 +470,6 @@ async def async_get_state(config) -> dict:
                     oppo_index
                 ]["score"]
                 values["last_update"] = arrow.now().format(arrow.FORMAT_W3C)
-                values["private_fast_refresh"] = False
 
         # Never found the team. Either a bye or a post-season condition
         if not found_team:
@@ -450,20 +506,6 @@ async def async_get_state(config) -> dict:
                 values["team_logo"] = None
                 values["state"] = "NOT_FOUND"
                 values["last_update"] = arrow.now().format(arrow.FORMAT_W3C)
-
-        if values["state"] == "PRE" and (
-            (arrow.get(values["date"]) - arrow.now()).total_seconds() < 1200
-        ):
-            _LOGGER.debug(
-                "Event is within 20 minutes, setting refresh rate to 5 seconds."
-            )
-            values["private_fast_refresh"] = True
-        elif values["state"] == "IN":
-            _LOGGER.debug("Event in progress, setting refresh rate to 5 seconds.")
-            values["private_fast_refresh"] = True
-        elif values["state"] in ["POST", "BYE"]:
-            _LOGGER.debug("Event is over, setting refresh back to 10 minutes.")
-            values["private_fast_refresh"] = False
 
     return values
 
@@ -504,7 +546,6 @@ async def async_clear_states(config) -> dict:
         "opponent_win_probability": None,
         "opponent_timeouts": None,
         "last_update": None,
-        "private_fast_refresh": False,
     }
 
     return values

--- a/custom_components/nfl/manifest.json
+++ b/custom_components/nfl/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "arrow"
   ],
-  "version": "0.7"
+  "version": "0.7.1"
 }

--- a/custom_components/nfl/sensor.py
+++ b/custom_components/nfl/sensor.py
@@ -1,5 +1,6 @@
 import logging
 import uuid
+from types import SimpleNamespace
 
 import voluptuous as vol
 from homeassistant.components.sensor import PLATFORM_SCHEMA
@@ -35,28 +36,31 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Configuration from yaml"""
-    if DOMAIN not in hass.data.keys():
-        hass.data.setdefault(DOMAIN, {})
-        config.entry_id = slugify(f"{config.get(CONF_TEAM_ID)}")
-        config.data = config
-    else:
-        config.entry_id = slugify(f"{config.get(CONF_TEAM_ID)}")
-        config.data = config
+    hass.data.setdefault(DOMAIN, {})
+
+    # In HA 2024.05+ the YAML `config` is an immutable NodeDictClass, so we can
+    # no longer attach `entry_id`/`data` attributes to it directly. Wrap it in a
+    # lightweight object that mimics the ConfigEntry interface (entry_id + data)
+    # the rest of the platform expects.
+    entry = SimpleNamespace(
+        entry_id=slugify(f"{config.get(CONF_TEAM_ID)}"),
+        data=dict(config),
+    )
 
     # Setup the data coordinator
     coordinator = NFLDataUpdateCoordinator(
         hass,
-        config,
-        config[CONF_TIMEOUT],
+        entry.data,
+        entry.data.get(CONF_TIMEOUT),
     )
 
     # Fetch initial data so we have data when entities subscribe
     await coordinator.async_refresh()
 
-    hass.data[DOMAIN][config.entry_id] = {
+    hass.data[DOMAIN][entry.entry_id] = {
         COORDINATOR: coordinator,
     }
-    async_add_entities([NFLScoresSensor(hass, config)], True)
+    async_add_entities([NFLScoresSensor(hass, entry)], True)
 
 
 async def async_setup_entry(hass, entry, async_add_entities):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -10,7 +10,14 @@ from homeassistant.helpers.entity_registry import async_get
 from homeassistant.setup import async_setup_component
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.nfl import _LOGGER, NFLDataUpdateCoordinator
+from custom_components.nfl import (
+    DEFAULT_SCAN_INTERVAL,
+    LIVE_SCAN_INTERVAL,
+    MIN_PREGAME_SCAN_INTERVAL,
+    _LOGGER,
+    _compute_update_interval,
+    NFLDataUpdateCoordinator,
+)
 from custom_components.nfl.const import CONF_TEAM_ID, DOMAIN
 from tests.const import CONFIG_DATA
 
@@ -93,6 +100,47 @@ def test_coordinator_passes_config_entry(hass):
         name=CONFIG_DATA[CONF_NAME],
         update_interval=timedelta(minutes=10),
     )
+
+
+def test_update_interval_live_is_fast():
+    """A live game polls at the fast live cadence."""
+    assert _compute_update_interval("IN", 0) == LIVE_SCAN_INTERVAL
+    # Case-insensitive and independent of any kickoff value.
+    assert _compute_update_interval("in", None) == LIVE_SCAN_INTERVAL
+
+
+def test_update_interval_finished_or_idle_is_default():
+    """Finished/idle states fall back to the default cadence."""
+    for state in ("POST", "BYE", "NOT_FOUND", "", None):
+        assert _compute_update_interval(state, None) == DEFAULT_SCAN_INTERVAL
+
+
+def test_update_interval_imminent_kickoff_is_fast():
+    """PRE within the imminent window (or past kickoff) polls fast."""
+    # Already elapsed but still reported as PRE (ESPN lag).
+    assert _compute_update_interval("PRE", -30) == MIN_PREGAME_SCAN_INTERVAL
+    # Exactly at / just inside the 60s window.
+    assert _compute_update_interval("PRE", 60) == MIN_PREGAME_SCAN_INTERVAL
+    assert _compute_update_interval("PRE", 30) == MIN_PREGAME_SCAN_INTERVAL
+    # Unknown kickoff time is treated as imminent.
+    assert _compute_update_interval("PRE", None) == MIN_PREGAME_SCAN_INTERVAL
+
+
+def test_update_interval_pregame_scales_and_converges():
+    """Pre-game cadence halves the remaining time, clamped to sane bounds."""
+    # Far out: capped at the default cadence, never longer.
+    assert _compute_update_interval("PRE", 24 * 3600) == DEFAULT_SCAN_INTERVAL
+    # Mid-range: half of the remaining time.
+    assert _compute_update_interval("PRE", 600) == timedelta(seconds=300)
+    assert _compute_update_interval("PRE", 200) == timedelta(seconds=100)
+    # As kickoff approaches the interval keeps shrinking (monotonic), so the
+    # final pre-game poll lands within seconds of kickoff.
+    prev = DEFAULT_SCAN_INTERVAL
+    for secs in (3600, 1800, 900, 300, 120, 61):
+        current = _compute_update_interval("PRE", secs)
+        assert current <= prev
+        assert current >= MIN_PREGAME_SCAN_INTERVAL
+        prev = current
 
 
 # async def test_import(hass):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -25,3 +25,35 @@ async def test_sensor(hass):
     await hass.async_block_till_done()
 
     assert "nfl" in hass.config.components
+
+
+async def test_setup_platform_yaml(hass):
+    """YAML setup must handle the immutable NodeDictClass config (#49)."""
+    try:
+        from homeassistant.util.yaml.objects import NodeDictClass
+    except ImportError:  # older Home Assistant
+        from homeassistant.util.yaml import NodeDictClass
+
+    from custom_components.nfl.sensor import async_setup_platform
+
+    # A real YAML config object; attributes cannot be assigned onto it, which is
+    # exactly what broke the previous implementation on HA 2024.05+.
+    config = NodeDictClass()
+    config.update({"platform": "nfl", "name": "NFL", "team_id": "SEA", "timeout": 120})
+
+    added = []
+
+    def _add_entities(entities, update_before_add=False):
+        added.extend(entities)
+
+    with patch(
+        "custom_components.nfl.NFLDataUpdateCoordinator.async_refresh",
+        new=AsyncMock(return_value=None),
+    ):
+        await async_setup_platform(hass, config, _add_entities)
+    await hass.async_block_till_done()
+
+    # One sensor created, and the coordinator registered under a slugified id
+    # derived from the team without mutating the original config object.
+    assert len(added) == 1
+    assert "sea" in hass.data[DOMAIN]


### PR DESCRIPTION
Addresses two open issues. Separate commits per issue.

## #49 — YAML configuration broken on HA 2024.05+

`async_setup_platform` mutated the YAML config object:

```python
config.entry_id = slugify(f"{config.get(CONF_TEAM_ID)}")
config.data = config
```

Since HA 2024.05 the YAML `config` is an immutable `NodeDictClass` (uses `__slots__`), so those assignments raise:

```
AttributeError: 'NodeDictClass' object has no attribute 'entry_id'
```

…breaking every sensor configured via `configuration.yaml` (a path still documented in the README).

**Fix:** wrap the config in a lightweight `SimpleNamespace` that mimics the `ConfigEntry` interface (`entry_id` + `data`) the rest of the platform already expects, instead of mutating the original mapping. Also collapsed the duplicated `if/else` branches that did the same thing.

**Test:** `test_setup_platform_yaml` drives `async_setup_platform` with a real `NodeDictClass` (which reproduces the crash on the old code) and asserts a sensor is created and the coordinator registered.

## #46 — Slow updates near kickoff (adaptive cadence)

The coordinator used a fixed **20-minute** pre-game window: outside it, polling stayed at the 10-minute base cadence; only inside it did polling jump to every 5 s. Consequences:
- For most of the hour before kickoff, updates were coarse (10 min).
- Entering fast mode depended on a poll happening to land in the fixed window.
- The binary flag (`private_fast_refresh`) was computed in `async_get_state` and consumed in `_async_update_data`, splitting the timing logic.

**Fix:** replace the fixed window with an interval that **scales with time-to-kickoff**, via a pure, unit-tested helper `_compute_update_interval(state, seconds_to_kickoff)`:

- **Live (`IN`)** → 5 s.
- **Pre-game (`PRE`)** → halve the remaining time, clamped between 5 s and 10 min. The cadence converges on kickoff (e.g. 60 min out → ~30 min wait; 20 → 10; 10 → 5; 2 → 1; ≤60 s → 5 s), so the final pre-game poll lands within seconds of kickoff **without** polling every 5 s for a long fixed window.
- **Kickoff unknown or already elapsed while still `PRE`** (ESPN reporting lag) → treated as imminent (5 s).
- **`POST` / `BYE` / `NOT_FOUND` / unexpected** → 10 min.

Interval selection now lives in the coordinator (driven by `state` + `date`); the `private_fast_refresh` flag is removed. Tunables are module constants (`DEFAULT_SCAN_INTERVAL`, `LIVE_SCAN_INTERVAL`, `MIN_PREGAME_SCAN_INTERVAL`, `IMMINENT_KICKOFF_WINDOW`).

**Note on scope:** part of the originally-reported "~4 minutes late" is upstream — ESPN's own `PRE → IN` transition trails real kickoff — which no client-side cadence can fix. This change minimizes the *integration-side* latency and removes the fixed-window fragility.

## Verification

Full suite on Python 3.13 / `homeassistant==2026.2.3` (both CI invocations):

```
10 passed
```

New tests cover the YAML path and the interval helper across live/pre-game/finished/imminent/far-out cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRC5To1VHVRMUcD4u2faqM)_